### PR TITLE
Make driver compliant with REP 145

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,18 +68,25 @@ None.
 
 ~frame_id (string, default: imu_link)
   The frame ID to set in outgoing messages.
+
 ~linear_acceleration_stddev (double, default: 0.1)
   Square root of the linear_acceleration_covariance diagonal elements in m/s^2. Overrides any values reported by the sensor.
+
 ~angular_velocity_stddev (double, default: 0.1)
   Square root of the angular_velocity_covariance diagonal elements in rad/s. Overrides any values reported by the sensor.
+
 ~magnetic_field_stddev (double, default: 0.1)
   Square root of the magnetic_field_covariance diagonal elements in Tesla. Overrides any values reported by the sensor.
+
 ~orientation_stddev (double, default: 0.1)
   Square root of the orientation_covariance diagonal elements in rad. Overrides any values reported by the sensor.
+
 ~port (int, default: 4223)
   Port of the tinkerforge brickv server.
+
 ~ip (string, default: localhost)
   Ip of the tinkerforge brickv server.
+
 ~rate (int, default: 100)
   Sample frequency of the sensor in Hz.
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ None.
   Port of the tinkerforge brickv server.
 ~ip (string, default: localhost)
   Ip of the tinkerforge brickv server.
-~rate (int, default: 10)
+~rate (int, default: 100)
   Sample frequency of the sensor in Hz.
 
 ### Required tf Transforms

--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ None.
 
 ### Published topics
 
-tfsensors/imuN([sensor_msgs/Imu Message](http://docs.ros.org/melodic/api/sensor_msgs/html/msg/Imu.html))
-  IMU message, in which N starts at 1 and counts up, if multiple imu's are connected.
+*  tfsensors/imuN([sensor_msgs/Imu Message](http://docs.ros.org/melodic/api/sensor_msgs/html/msg/Imu.html))
+   * IMU message, in which N starts at 1 and counts up, if multiple imu's are connected.
 
-tfsensors/magneticN([sensor_msgs/MagneticField Message](http://docs.ros.org/melodic/api/sensor_msgs/html/msg/MagneticField.html))
-  IMU message, in which N starts at 1 and counts up, if multiple imu's are connected.
+* tfsensors/magneticN([sensor_msgs/MagneticField Message](http://docs.ros.org/melodic/api/sensor_msgs/html/msg/MagneticField.html))
+   * IMU message, in which N starts at 1 and counts up, if multiple imu's are connected.
 
 ### Services
 
@@ -66,29 +66,29 @@ None.
 
 ### Parameters
 
-~frame_id (string, default: imu_link)
-The frame ID to set in outgoing messages.
+* ~frame_id (string, default: imu_link)
+   * The frame ID to set in outgoing messages.
 
-~linear_acceleration_stddev (double, default: 0.1)
-Square root of the linear_acceleration_covariance diagonal elements in m/s^2. Overrides any values reported by the sensor.
+* ~linear_acceleration_stddev (double, default: 0.1)
+   * Square root of the linear_acceleration_covariance diagonal elements in m/s^2. Overrides any values reported by the sensor.
 
-~angular_velocity_stddev (double, default: 0.1)
-Square root of the angular_velocity_covariance diagonal elements in rad/s. Overrides any values reported by the sensor.
+* ~angular_velocity_stddev (double, default: 0.1)
+   * Square root of the angular_velocity_covariance diagonal elements in rad/s. Overrides any values reported by the sensor.
 
-~magnetic_field_stddev (double, default: 0.1)
-Square root of the magnetic_field_covariance diagonal elements in Tesla. Overrides any values reported by the sensor.
+* ~magnetic_field_stddev (double, default: 0.1)
+   * Square root of the magnetic_field_covariance diagonal elements in Tesla. Overrides any values reported by the sensor.
 
-~orientation_stddev (double, default: 0.1)
-Square root of the orientation_covariance diagonal elements in rad. Overrides any values reported by the sensor.
+* ~orientation_stddev (double, default: 0.1)
+   * Square root of the orientation_covariance diagonal elements in rad. Overrides any values reported by the sensor.
 
-~port (int, default: 4223)
-Port of the tinkerforge brickv server.
+* ~port (int, default: 4223)
+   * Port of the tinkerforge brickv server.
 
-~ip (string, default: localhost)
-Ip of the tinkerforge brickv server.
+* ~ip (string, default: localhost)
+   * Ip of the tinkerforge brickv server.
 
-~rate (int, default: 100)
-Sample frequency of the sensor in Hz.
+* ~rate (int, default: 100)
+   * Sample frequency of the sensor in Hz.
 
 ### Required tf Transforms
 

--- a/README.md
+++ b/README.md
@@ -39,19 +39,60 @@ Workspace kompilieren / build workspace
 
 `catkin_make`
 
-### Ausführen / run node
-
-`rosrun tinkerforge_sensors tinkerforge_sensors_node`
-
-### Launchfile
-
-Argumente
-* port (int) *Tinkerforge Port*
-* ip (string) *Tinkerforge IP*
-
+# Example
+To start using the TinkerForge sensors node, use the example launch file:
 `roslaunch tinkerforge_sensors tinkerforge_sensors.launch`
 
-### ToDo
+# Nodes
+
+## tinkerforge_sensors
+The tinkerforge_sensors node connects to the brickd application and publishes the data on the `/tfsensors/` topic.
+
+### Subscribed topics
+
+None.
+
+### Published topics
+
+tfsensors/imuN([sensor_msgs/Imu Message](http://docs.ros.org/melodic/api/sensor_msgs/html/msg/Imu.html))
+  IMU message, in which N starts at 1 and counts up, if multiple imu's are connected.
+
+tfsensors/magneticN([sensor_msgs/MagneticField Message](http://docs.ros.org/melodic/api/sensor_msgs/html/msg/MagneticField.html))
+  IMU message, in which N starts at 1 and counts up, if multiple imu's are connected.
+
+### Services
+
+None.
+
+### Parameters
+
+~frame_id (string, default: imu_link)
+  The frame ID to set in outgoing messages.
+~linear_acceleration_stddev (double, default: 0.1)
+  Square root of the linear_acceleration_covariance diagonal elements in m/s^2. Overrides any values reported by the sensor.
+~angular_velocity_stddev (double, default: 0.1)
+  Square root of the angular_velocity_covariance diagonal elements in rad/s. Overrides any values reported by the sensor.
+~magnetic_field_stddev (double, default: 0.1)
+  Square root of the magnetic_field_covariance diagonal elements in Tesla. Overrides any values reported by the sensor.
+~orientation_stddev (double, default: 0.1)
+  Square root of the orientation_covariance diagonal elements in rad. Overrides any values reported by the sensor.
+~port (int, default: 4223)
+  Port of the tinkerforge brickv server.
+~ip (string, default: localhost)
+  Ip of the tinkerforge brickv server.
+~rate (int, default: 10)
+  Sample frequency of the sensor in Hz.
+
+### Required tf Transforms
+
+None.
+
+### Provided tf Transform
+
+None.
+
+
+# ToDo
 
 * mehr Sensoren unterstützen / suport more sensors
 * Kalibrierung für Distance US Sensor / calibration for Distance US sensor

--- a/README.md
+++ b/README.md
@@ -67,28 +67,28 @@ None.
 ### Parameters
 
 ~frame_id (string, default: imu_link)
-  The frame ID to set in outgoing messages.
+The frame ID to set in outgoing messages.
 
 ~linear_acceleration_stddev (double, default: 0.1)
-  Square root of the linear_acceleration_covariance diagonal elements in m/s^2. Overrides any values reported by the sensor.
+Square root of the linear_acceleration_covariance diagonal elements in m/s^2. Overrides any values reported by the sensor.
 
 ~angular_velocity_stddev (double, default: 0.1)
-  Square root of the angular_velocity_covariance diagonal elements in rad/s. Overrides any values reported by the sensor.
+Square root of the angular_velocity_covariance diagonal elements in rad/s. Overrides any values reported by the sensor.
 
 ~magnetic_field_stddev (double, default: 0.1)
-  Square root of the magnetic_field_covariance diagonal elements in Tesla. Overrides any values reported by the sensor.
+Square root of the magnetic_field_covariance diagonal elements in Tesla. Overrides any values reported by the sensor.
 
 ~orientation_stddev (double, default: 0.1)
-  Square root of the orientation_covariance diagonal elements in rad. Overrides any values reported by the sensor.
+Square root of the orientation_covariance diagonal elements in rad. Overrides any values reported by the sensor.
 
 ~port (int, default: 4223)
-  Port of the tinkerforge brickv server.
+Port of the tinkerforge brickv server.
 
 ~ip (string, default: localhost)
-  Ip of the tinkerforge brickv server.
+Ip of the tinkerforge brickv server.
 
 ~rate (int, default: 100)
-  Sample frequency of the sensor in Hz.
+Sample frequency of the sensor in Hz.
 
 ### Required tf Transforms
 

--- a/include/sensor_device.h
+++ b/include/sensor_device.h
@@ -28,13 +28,7 @@ struct SensorConf
 class SensorDevice
 {
 public:
-  SensorDevice(void *dev,
-               std::string uid,
-               std::string topic,
-               uint16_t type,
-               SensorClass sclass,
-               uint8_t rate,
-               std::string frame_id)
+  SensorDevice(void *dev, std::string uid, std::string topic, uint16_t type, SensorClass sclass, uint8_t rate)
   {
     this->dev = dev;
     this->uid = uid;
@@ -42,7 +36,7 @@ public:
     this->type = type;
     this->sclass = sclass;
     this->rate = rate;
-    this->frame = frame_id;
+    this->frame = "/base_link";
     //this->pub = NULL;
     if (topic.size() == 0)
       buildTopic(this);

--- a/include/sensor_device.h
+++ b/include/sensor_device.h
@@ -28,7 +28,13 @@ struct SensorConf
 class SensorDevice
 {
 public:
-  SensorDevice(void *dev, std::string uid, std::string topic, uint16_t type, SensorClass sclass, uint8_t rate)
+  SensorDevice(void *dev,
+               std::string uid,
+               std::string topic,
+               uint16_t type,
+               SensorClass sclass,
+               uint8_t rate,
+               std::string frame_id)
   {
     this->dev = dev;
     this->uid = uid;
@@ -36,7 +42,7 @@ public:
     this->type = type;
     this->sclass = sclass;
     this->rate = rate;
-    this->frame = "/base_link";
+    this->frame = frame_id;
     //this->pub = NULL;
     if (topic.size() == 0)
       buildTopic(this);

--- a/include/tinkerforge_sensors_core.h
+++ b/include/tinkerforge_sensors_core.h
@@ -87,6 +87,11 @@ private:
   std::string host;
   //! The Tinkerforge PORT
   int port;
+  //! IMU covariances
+  double linear_acceleration_stddev;
+  double angular_velocity_stddev;
+  double magnetic_field_stddev;
+  double orientation_stddev;
   //! The IMU convergence_speed
   int imu_convergence_speed;
   //! Time to correct the imu orientation

--- a/include/tinkerforge_sensors_core.h
+++ b/include/tinkerforge_sensors_core.h
@@ -28,6 +28,7 @@ public:
 
   TinkerforgeSensors(std::string topic,
                      int port,
+                     std::string frame_id,
                      double linear_acceleration_stddev,
                      double angular_velocity_stddev,
                      double magnetic_field_stddev,
@@ -92,6 +93,8 @@ private:
   std::string host;
   //! The Tinkerforge PORT
   int port;
+  //! frame_id
+  std::string frame_id;
   //! IMU covariances
   double linear_acceleration_stddev;
   double angular_velocity_stddev;

--- a/include/tinkerforge_sensors_core.h
+++ b/include/tinkerforge_sensors_core.h
@@ -26,7 +26,12 @@ public:
   //! Constructur
   TinkerforgeSensors();
 
-  TinkerforgeSensors(std::string topic, int port);
+  TinkerforgeSensors(std::string topic,
+                     int port,
+                     double linear_acceleration_stddev,
+                     double angular_velocity_stddev,
+                     double magnetic_field_stddev,
+                     double orientation_stddev);
 
   //! Destructor
   ~TinkerforgeSensors();

--- a/launch/tinkerforge_sensors.launch
+++ b/launch/tinkerforge_sensors.launch
@@ -8,6 +8,7 @@
       angular_velocity_stddev : 0.1
       magnetic_field_stddev : 0.1
       orientation_stddev : 0.1
+      frame_id : "imu_link"
     </rosparam>
   </node>
 </launch>

--- a/launch/tinkerforge_sensors.launch
+++ b/launch/tinkerforge_sensors.launch
@@ -3,5 +3,11 @@
     <rosparam param="UID_to_Topic">
       6wViuNa : 'imu_v2'
     </rosparam>
+    <rosparam>
+      linear_acceleration_stddev : 0.1
+      angular_velocity_stddev : 0.1
+      magnetic_field_stddev : 0.1
+      orientation_stddev : 0.1
+    </rosparam>
   </node>
 </launch>

--- a/src/tinkerforge_sensors_core.cpp
+++ b/src/tinkerforge_sensors_core.cpp
@@ -602,7 +602,7 @@ void TinkerforgeSensors::callbackEnumerate(const char *uid, const char *connecte
     imu_leds_on(imu);
     tfs->imu_init_time = ros::Time::now();
 
-    SensorDevice *imu_dev = new SensorDevice(imu, uid, topic, IMU_DEVICE_IDENTIFIER, SensorClass::IMU, 10, this->frame_id);
+    SensorDevice *imu_dev = new SensorDevice(imu, uid, topic, IMU_DEVICE_IDENTIFIER, SensorClass::IMU, 10);
     tfs->sensors.push_back(imu_dev);
   }
   else if (device_identifier == IMU_V2_DEVICE_IDENTIFIER)
@@ -613,10 +613,10 @@ void TinkerforgeSensors::callbackEnumerate(const char *uid, const char *connecte
     imu_v2_create(imu_v2, uid, &(tfs->ipcon));
     imu_leds_on(imu_v2);
 
-    SensorDevice *imu_dev = new SensorDevice(imu_v2, uid, topic, IMU_V2_DEVICE_IDENTIFIER, SensorClass::IMU, 10, this->frame_id);
+    SensorDevice *imu_dev = new SensorDevice(imu_v2, uid, topic, IMU_V2_DEVICE_IDENTIFIER, SensorClass::IMU, 10);
     tfs->sensors.push_back(imu_dev);
 
-    imu_dev = new SensorDevice(imu_v2, uid, std::string(""), IMU_V2_MAGNETIC_DEVICE_IDENTIFIER, SensorClass::MAGNETIC, 10, this->frame_id);
+    imu_dev = new SensorDevice(imu_v2, uid, std::string(""), IMU_V2_MAGNETIC_DEVICE_IDENTIFIER, SensorClass::MAGNETIC, 10);
     tfs->sensors.push_back(imu_dev);
     return;
   }
@@ -627,7 +627,7 @@ void TinkerforgeSensors::callbackEnumerate(const char *uid, const char *connecte
     GPS *gps = new GPS();
     gps_create(gps, uid, &(tfs->ipcon));
 
-    SensorDevice *gps_dev = new SensorDevice(gps, uid, topic, GPS_DEVICE_IDENTIFIER, SensorClass::GPS, 10, 10, this->frame_id);
+    SensorDevice *gps_dev = new SensorDevice(gps, uid, topic, GPS_DEVICE_IDENTIFIER, SensorClass::GPS, 10);
     tfs->sensors.push_back(gps_dev);
   }
   else if (device_identifier == DUAL_BUTTON_DEVICE_IDENTIFIER)
@@ -637,7 +637,7 @@ void TinkerforgeSensors::callbackEnumerate(const char *uid, const char *connecte
     DualButton *db = new DualButton();
     dual_button_create(db, uid, &(tfs->ipcon));
 
-    SensorDevice *db_dev = new SensorDevice(db, uid, topic, DUAL_BUTTON_DEVICE_IDENTIFIER, SensorClass::MISC, 10, 10, this->frame_id);
+    SensorDevice *db_dev = new SensorDevice(db, uid, topic, DUAL_BUTTON_DEVICE_IDENTIFIER, SensorClass::MISC, 10);
     tfs->sensors.push_back(db_dev);
   }
   else if (device_identifier == TEMPERATURE_DEVICE_IDENTIFIER)
@@ -647,7 +647,7 @@ void TinkerforgeSensors::callbackEnumerate(const char *uid, const char *connecte
     // Create Temperature device object
     temperature_create(temp, uid, &(tfs->ipcon));
 
-    SensorDevice *temp_dev = new SensorDevice(temp, uid, topic, TEMPERATURE_DEVICE_IDENTIFIER, SensorClass::TEMPERATURE, 10, 10, this->frame_id);
+    SensorDevice *temp_dev = new SensorDevice(temp, uid, topic, TEMPERATURE_DEVICE_IDENTIFIER, SensorClass::TEMPERATURE, 10);
     tfs->sensors.push_back(temp_dev);
 
   }
@@ -657,7 +657,7 @@ void TinkerforgeSensors::callbackEnumerate(const char *uid, const char *connecte
     // Create Ambient Light device object
     AmbientLight *ambient_light = new AmbientLight();
     ambient_light_create(ambient_light, uid, &(tfs->ipcon));
-    SensorDevice *ambient_light_dev = new SensorDevice(ambient_light, uid, topic, AMBIENT_LIGHT_DEVICE_IDENTIFIER, SensorClass::LIGHT, 10, 10, this->frame_id);
+    SensorDevice *ambient_light_dev = new SensorDevice(ambient_light, uid, topic, AMBIENT_LIGHT_DEVICE_IDENTIFIER, SensorClass::LIGHT, 10);
     tfs->sensors.push_back(ambient_light_dev);
   }
   else if (device_identifier == AMBIENT_LIGHT_V2_DEVICE_IDENTIFIER)
@@ -666,7 +666,7 @@ void TinkerforgeSensors::callbackEnumerate(const char *uid, const char *connecte
     // Create Ambient Light device object
     AmbientLightV2 *ambient_v2_light = new AmbientLightV2();
     ambient_light_create(ambient_v2_light, uid, &(tfs->ipcon));
-    SensorDevice *ambient_light_v2_dev = new SensorDevice(ambient_v2_light, uid, topic, AMBIENT_LIGHT_V2_DEVICE_IDENTIFIER, SensorClass::LIGHT, 10, 10, this->frame_id);
+    SensorDevice *ambient_light_v2_dev = new SensorDevice(ambient_v2_light, uid, topic, AMBIENT_LIGHT_V2_DEVICE_IDENTIFIER, SensorClass::LIGHT, 10);
     tfs->sensors.push_back(ambient_light_v2_dev);
   }
   else if (device_identifier == DISTANCE_IR_DEVICE_IDENTIFIER)
@@ -675,7 +675,7 @@ void TinkerforgeSensors::callbackEnumerate(const char *uid, const char *connecte
     // Create Distance IR device object
     DistanceIR *distance_ir = new DistanceIR();
     distance_ir_create(distance_ir, uid, &(tfs->ipcon));
-    SensorDevice *distance_ir_dev = new SensorDevice(distance_ir, uid, topic, DISTANCE_IR_DEVICE_IDENTIFIER, SensorClass::RANGE, 10, 10, this->frame_id);
+    SensorDevice *distance_ir_dev = new SensorDevice(distance_ir, uid, topic, DISTANCE_IR_DEVICE_IDENTIFIER, SensorClass::RANGE, 10);
     tfs->sensors.push_back(distance_ir_dev);
   }
   else if (device_identifier == DISTANCE_US_DEVICE_IDENTIFIER)
@@ -684,7 +684,7 @@ void TinkerforgeSensors::callbackEnumerate(const char *uid, const char *connecte
     // Create Distance US  device object
     DistanceUS *distance_us = new DistanceUS();
     distance_us_create(distance_us, uid, &(tfs->ipcon));
-    SensorDevice *distance_us_dev = new SensorDevice(distance_us, uid, topic, DISTANCE_US_DEVICE_IDENTIFIER, SensorClass::RANGE, 10, 10, this->frame_id);
+    SensorDevice *distance_us_dev = new SensorDevice(distance_us, uid, topic, DISTANCE_US_DEVICE_IDENTIFIER, SensorClass::RANGE, 10);
     tfs->sensors.push_back(distance_us_dev);
   }
   else if (device_identifier == MOTION_DETECTOR_DEVICE_IDENTIFIER)
@@ -693,7 +693,7 @@ void TinkerforgeSensors::callbackEnumerate(const char *uid, const char *connecte
     // Create Motion Detector  device object
     MotionDetector * md = new MotionDetector();
     motion_detector_create(md, uid, &(tfs->ipcon));
-    SensorDevice *md_dev = new SensorDevice(md, uid, topic, MOTION_DETECTOR_DEVICE_IDENTIFIER, SensorClass::MISC, 10, 10, this->frame_id);
+    SensorDevice *md_dev = new SensorDevice(md, uid, topic, MOTION_DETECTOR_DEVICE_IDENTIFIER, SensorClass::MISC, 10);
     tfs->sensors.push_back(md_dev);
   }
 }

--- a/src/tinkerforge_sensors_core.cpp
+++ b/src/tinkerforge_sensors_core.cpp
@@ -42,6 +42,7 @@ TinkerforgeSensors::TinkerforgeSensors()
 
 TinkerforgeSensors::TinkerforgeSensors(std::string host,
                                        int port,
+                                       std::string frame_id,
                                        double linear_acceleration_stddev,
                                        double angular_velocity_stddev,
                                        double magnetic_field_stddev,
@@ -56,6 +57,7 @@ TinkerforgeSensors::TinkerforgeSensors(std::string host,
   else
     this->port = port;
 
+  this->frame_id = frame_id;
   this->linear_acceleration_stddev = linear_acceleration_stddev;
   this->angular_velocity_stddev = angular_velocity_stddev;
   this->magnetic_field_stddev = magnetic_field_stddev;
@@ -234,7 +236,7 @@ void TinkerforgeSensors::publishImuMessage(SensorDevice *sensor)
     // message header
     imu_msg.header.seq = sensor->getSeq();
     imu_msg.header.stamp = current_time;
-    imu_msg.header.frame_id = sensor->getFrame();
+    imu_msg.header.frame_id = std::string("/") + this->frame_id;
 
     // orientation_covariance
     boost::array<const double, 9> oc =

--- a/src/tinkerforge_sensors_core.cpp
+++ b/src/tinkerforge_sensors_core.cpp
@@ -40,7 +40,12 @@ TinkerforgeSensors::TinkerforgeSensors()
   imu_convergence_speed = 0;
 }
 
-TinkerforgeSensors::TinkerforgeSensors(std::string host, int port)
+TinkerforgeSensors::TinkerforgeSensors(std::string host,
+                                       int port,
+                                       double linear_acceleration_stddev,
+                                       double angular_velocity_stddev,
+                                       double magnetic_field_stddev,
+                                       double orientation_stddev)
 {
   if (host.length() == 0)
     this->host = "localhost";
@@ -50,6 +55,12 @@ TinkerforgeSensors::TinkerforgeSensors(std::string host, int port)
     this->port = 4223;
   else
     this->port = port;
+
+  this->linear_acceleration_stddev = linear_acceleration_stddev;
+  this->angular_velocity_stddev = angular_velocity_stddev;
+  this->magnetic_field_stddev = magnetic_field_stddev;
+  this->orientation_stddev = orientation_stddev;
+
 }
 
 /*----------------------------------------------------------------------
@@ -182,7 +193,7 @@ void TinkerforgeSensors::publishImuMessage(SensorDevice *sensor)
       f_acc_x = (float(acc_x)/1000.0)*9.80605;
       f_acc_y = (float(acc_y)/1000.0)*9.80605;
       f_acc_z = (float(acc_z)/1000.0)*9.80605;
-      
+
       imu_msg.orientation.x = w;
       imu_msg.orientation.y = z*-1;
       imu_msg.orientation.z = y;
@@ -208,7 +219,7 @@ void TinkerforgeSensors::publishImuMessage(SensorDevice *sensor)
       f_acc_x = float(acc_x) / 100.0;
       f_acc_y = float(acc_y) / 100.0;
       f_acc_z = float(acc_z) / 100.0;
-      
+
       imu_msg.orientation.x = y;
       imu_msg.orientation.y = z;
       imu_msg.orientation.z = w;
@@ -491,7 +502,7 @@ void TinkerforgeSensors::publishIlluminanceMessage(SensorDevice *sensor)
     illum_msg.header.seq =  sensor->getSeq();
     illum_msg.header.stamp = ros::Time::now();
     illum_msg.header.frame_id = sensor->getFrame();
-    
+
     illum_msg.illuminance = illuminance;
     illum_msg.variance = 0;
 
@@ -622,7 +633,7 @@ void TinkerforgeSensors::callbackEnumerate(const char *uid, const char *connecte
   else if (device_identifier == DUAL_BUTTON_DEVICE_IDENTIFIER)
   {
     ROS_INFO_STREAM("found DualButton with UID:" << uid);
-    
+
     DualButton *db = new DualButton();
     dual_button_create(db, uid, &(tfs->ipcon));
 

--- a/src/tinkerforge_sensors_core.cpp
+++ b/src/tinkerforge_sensors_core.cpp
@@ -238,9 +238,9 @@ void TinkerforgeSensors::publishImuMessage(SensorDevice *sensor)
 
     // orientation_covariance
     boost::array<const double, 9> oc =
-      { 0.1, 0.1, 0.1,
-        0.1, 0.1, 0.1,
-        0.1, 0.1, 0.1};
+      { this->orientation_stddev, 0, 0,
+        0, this->orientation_stddev, 0,
+        0, 0, this->orientation_stddev};
 
     imu_msg.orientation_covariance = oc;
 
@@ -251,9 +251,9 @@ void TinkerforgeSensors::publishImuMessage(SensorDevice *sensor)
 
     // velocity_covariance
     boost::array<const double, 9> vc =
-      { 0.1, 0.1, 0.1,
-        0.1, 0.1, 0.1,
-        0.1, 0.1, 0.1};
+    { this->angular_velocity_stddev, 0, 0,
+      0, this->angular_velocity_stddev, 0,
+      0, 0, this->angular_velocity_stddev};
     imu_msg.angular_velocity_covariance = vc;
 
     imu_msg.linear_acceleration.x = f_acc_x;
@@ -262,9 +262,9 @@ void TinkerforgeSensors::publishImuMessage(SensorDevice *sensor)
 
     // linear_acceleration_covariance
     boost::array<const double, 9> lac =
-      { 0.1, 0.1, 0.1,
-        0.1, 0.1, 0.1,
-        0.1, 0.1, 0.1};
+    { this->linear_acceleration_stddev, 0, 0,
+      0, this->linear_acceleration_stddev, 0,
+      0, 0, this->linear_acceleration_stddev};
     imu_msg.linear_acceleration_covariance = lac;
 
     sensor->getPub().publish(imu_msg);
@@ -317,9 +317,9 @@ void TinkerforgeSensors::publishMagneticFieldMessage(SensorDevice *sensor)
     mf_msg.magnetic_field.z = z;
 
     boost::array<const double, 9> mfc =
-      { 0.01, 0.01, 0.01,
-        0.01, 0.01, 0.01,
-        0.01, 0.01, 0.01};
+    { this->magnetic_field_stddev, 0, 0,
+      0, this->magnetic_field_stddev, 0,
+      0, 0, this->magnetic_field_stddev};
 
     mf_msg.magnetic_field_covariance = mfc;
 

--- a/src/tinkerforge_sensors_core.cpp
+++ b/src/tinkerforge_sensors_core.cpp
@@ -602,7 +602,7 @@ void TinkerforgeSensors::callbackEnumerate(const char *uid, const char *connecte
     imu_leds_on(imu);
     tfs->imu_init_time = ros::Time::now();
 
-    SensorDevice *imu_dev = new SensorDevice(imu, uid, topic, IMU_DEVICE_IDENTIFIER, SensorClass::IMU, 10);
+    SensorDevice *imu_dev = new SensorDevice(imu, uid, topic, IMU_DEVICE_IDENTIFIER, SensorClass::IMU, 10, this->frame_id);
     tfs->sensors.push_back(imu_dev);
   }
   else if (device_identifier == IMU_V2_DEVICE_IDENTIFIER)
@@ -613,10 +613,10 @@ void TinkerforgeSensors::callbackEnumerate(const char *uid, const char *connecte
     imu_v2_create(imu_v2, uid, &(tfs->ipcon));
     imu_leds_on(imu_v2);
 
-    SensorDevice *imu_dev = new SensorDevice(imu_v2, uid, topic, IMU_V2_DEVICE_IDENTIFIER, SensorClass::IMU, 10);
+    SensorDevice *imu_dev = new SensorDevice(imu_v2, uid, topic, IMU_V2_DEVICE_IDENTIFIER, SensorClass::IMU, 10, this->frame_id);
     tfs->sensors.push_back(imu_dev);
 
-    imu_dev = new SensorDevice(imu_v2, uid, std::string(""), IMU_V2_MAGNETIC_DEVICE_IDENTIFIER, SensorClass::MAGNETIC, 10);
+    imu_dev = new SensorDevice(imu_v2, uid, std::string(""), IMU_V2_MAGNETIC_DEVICE_IDENTIFIER, SensorClass::MAGNETIC, 10, this->frame_id);
     tfs->sensors.push_back(imu_dev);
     return;
   }
@@ -627,7 +627,7 @@ void TinkerforgeSensors::callbackEnumerate(const char *uid, const char *connecte
     GPS *gps = new GPS();
     gps_create(gps, uid, &(tfs->ipcon));
 
-    SensorDevice *gps_dev = new SensorDevice(gps, uid, topic, GPS_DEVICE_IDENTIFIER, SensorClass::GPS, 10);
+    SensorDevice *gps_dev = new SensorDevice(gps, uid, topic, GPS_DEVICE_IDENTIFIER, SensorClass::GPS, 10, 10, this->frame_id);
     tfs->sensors.push_back(gps_dev);
   }
   else if (device_identifier == DUAL_BUTTON_DEVICE_IDENTIFIER)
@@ -637,7 +637,7 @@ void TinkerforgeSensors::callbackEnumerate(const char *uid, const char *connecte
     DualButton *db = new DualButton();
     dual_button_create(db, uid, &(tfs->ipcon));
 
-    SensorDevice *db_dev = new SensorDevice(db, uid, topic, DUAL_BUTTON_DEVICE_IDENTIFIER, SensorClass::MISC, 10);
+    SensorDevice *db_dev = new SensorDevice(db, uid, topic, DUAL_BUTTON_DEVICE_IDENTIFIER, SensorClass::MISC, 10, 10, this->frame_id);
     tfs->sensors.push_back(db_dev);
   }
   else if (device_identifier == TEMPERATURE_DEVICE_IDENTIFIER)
@@ -647,7 +647,7 @@ void TinkerforgeSensors::callbackEnumerate(const char *uid, const char *connecte
     // Create Temperature device object
     temperature_create(temp, uid, &(tfs->ipcon));
 
-    SensorDevice *temp_dev = new SensorDevice(temp, uid, topic, TEMPERATURE_DEVICE_IDENTIFIER, SensorClass::TEMPERATURE, 10);
+    SensorDevice *temp_dev = new SensorDevice(temp, uid, topic, TEMPERATURE_DEVICE_IDENTIFIER, SensorClass::TEMPERATURE, 10, 10, this->frame_id);
     tfs->sensors.push_back(temp_dev);
 
   }
@@ -657,7 +657,7 @@ void TinkerforgeSensors::callbackEnumerate(const char *uid, const char *connecte
     // Create Ambient Light device object
     AmbientLight *ambient_light = new AmbientLight();
     ambient_light_create(ambient_light, uid, &(tfs->ipcon));
-    SensorDevice *ambient_light_dev = new SensorDevice(ambient_light, uid, topic, AMBIENT_LIGHT_DEVICE_IDENTIFIER, SensorClass::LIGHT, 10);
+    SensorDevice *ambient_light_dev = new SensorDevice(ambient_light, uid, topic, AMBIENT_LIGHT_DEVICE_IDENTIFIER, SensorClass::LIGHT, 10, 10, this->frame_id);
     tfs->sensors.push_back(ambient_light_dev);
   }
   else if (device_identifier == AMBIENT_LIGHT_V2_DEVICE_IDENTIFIER)
@@ -666,7 +666,7 @@ void TinkerforgeSensors::callbackEnumerate(const char *uid, const char *connecte
     // Create Ambient Light device object
     AmbientLightV2 *ambient_v2_light = new AmbientLightV2();
     ambient_light_create(ambient_v2_light, uid, &(tfs->ipcon));
-    SensorDevice *ambient_light_v2_dev = new SensorDevice(ambient_v2_light, uid, topic, AMBIENT_LIGHT_V2_DEVICE_IDENTIFIER, SensorClass::LIGHT, 10);
+    SensorDevice *ambient_light_v2_dev = new SensorDevice(ambient_v2_light, uid, topic, AMBIENT_LIGHT_V2_DEVICE_IDENTIFIER, SensorClass::LIGHT, 10, 10, this->frame_id);
     tfs->sensors.push_back(ambient_light_v2_dev);
   }
   else if (device_identifier == DISTANCE_IR_DEVICE_IDENTIFIER)
@@ -675,7 +675,7 @@ void TinkerforgeSensors::callbackEnumerate(const char *uid, const char *connecte
     // Create Distance IR device object
     DistanceIR *distance_ir = new DistanceIR();
     distance_ir_create(distance_ir, uid, &(tfs->ipcon));
-    SensorDevice *distance_ir_dev = new SensorDevice(distance_ir, uid, topic, DISTANCE_IR_DEVICE_IDENTIFIER, SensorClass::RANGE, 10);
+    SensorDevice *distance_ir_dev = new SensorDevice(distance_ir, uid, topic, DISTANCE_IR_DEVICE_IDENTIFIER, SensorClass::RANGE, 10, 10, this->frame_id);
     tfs->sensors.push_back(distance_ir_dev);
   }
   else if (device_identifier == DISTANCE_US_DEVICE_IDENTIFIER)
@@ -684,7 +684,7 @@ void TinkerforgeSensors::callbackEnumerate(const char *uid, const char *connecte
     // Create Distance US  device object
     DistanceUS *distance_us = new DistanceUS();
     distance_us_create(distance_us, uid, &(tfs->ipcon));
-    SensorDevice *distance_us_dev = new SensorDevice(distance_us, uid, topic, DISTANCE_US_DEVICE_IDENTIFIER, SensorClass::RANGE, 10);
+    SensorDevice *distance_us_dev = new SensorDevice(distance_us, uid, topic, DISTANCE_US_DEVICE_IDENTIFIER, SensorClass::RANGE, 10, 10, this->frame_id);
     tfs->sensors.push_back(distance_us_dev);
   }
   else if (device_identifier == MOTION_DETECTOR_DEVICE_IDENTIFIER)
@@ -693,7 +693,7 @@ void TinkerforgeSensors::callbackEnumerate(const char *uid, const char *connecte
     // Create Motion Detector  device object
     MotionDetector * md = new MotionDetector();
     motion_detector_create(md, uid, &(tfs->ipcon));
-    SensorDevice *md_dev = new SensorDevice(md, uid, topic, MOTION_DETECTOR_DEVICE_IDENTIFIER, SensorClass::MISC, 10);
+    SensorDevice *md_dev = new SensorDevice(md, uid, topic, MOTION_DETECTOR_DEVICE_IDENTIFIER, SensorClass::MISC, 10, 10, this->frame_id);
     tfs->sensors.push_back(md_dev);
   }
 }

--- a/src/tinkerforge_sensors_node.cpp
+++ b/src/tinkerforge_sensors_node.cpp
@@ -28,6 +28,10 @@ int main (int argc, char **argv)
   int imu_convergence_speed;
   int port;
   string host;
+  double linear_acceleration_stddev;
+  double angular_velocity_stddev;
+  double magnetic_field_stddev;
+  double orientation_stddev;
 
   signal(SIGINT, sigintHandler);
 

--- a/src/tinkerforge_sensors_node.cpp
+++ b/src/tinkerforge_sensors_node.cpp
@@ -38,7 +38,7 @@ int main (int argc, char **argv)
 
   // while using different parameters.
   ros::NodeHandle private_node_handle_("~");
-  private_node_handle_.param("rate", rate, int(10));
+  private_node_handle_.param("rate", rate, int(100));
   private_node_handle_.param("host", host, string("localhost"));
   private_node_handle_.param("port", port, int(4223));
   private_node_handle_.param("frame_id", frame_id, string("imu_link"));

--- a/src/tinkerforge_sensors_node.cpp
+++ b/src/tinkerforge_sensors_node.cpp
@@ -28,6 +28,7 @@ int main (int argc, char **argv)
   int imu_convergence_speed;
   int port;
   string host;
+  string frame_id;
   double linear_acceleration_stddev;
   double angular_velocity_stddev;
   double magnetic_field_stddev;
@@ -40,6 +41,7 @@ int main (int argc, char **argv)
   private_node_handle_.param("rate", rate, int(10));
   private_node_handle_.param("host", host, string("localhost"));
   private_node_handle_.param("port", port, int(4223));
+  private_node_handle_.param("frame_id", frame_id, string("imu_link"));
   private_node_handle_.param("linear_acceleration_stddev", linear_acceleration_stddev, double(0.1));
   private_node_handle_.param("angular_velocity_stddev", angular_velocity_stddev, double(0.1));
   private_node_handle_.param("magnetic_field_stddev", magnetic_field_stddev, double(0.1));
@@ -49,6 +51,7 @@ int main (int argc, char **argv)
   // create a new LaserTransformer object.
   TinkerforgeSensors *node_tfs = new TinkerforgeSensors(host,
                                                         port,
+                                                        frame_id,
                                                         linear_acceleration_stddev,
                                                         angular_velocity_stddev,
                                                         magnetic_field_stddev,

--- a/src/tinkerforge_sensors_node.cpp
+++ b/src/tinkerforge_sensors_node.cpp
@@ -47,7 +47,12 @@ int main (int argc, char **argv)
 
 
   // create a new LaserTransformer object.
-  TinkerforgeSensors *node_tfs = new TinkerforgeSensors(host, port);
+  TinkerforgeSensors *node_tfs = new TinkerforgeSensors(host,
+                                                        port,
+                                                        linear_acceleration_stddev,
+                                                        angular_velocity_stddev,
+                                                        magnetic_field_stddev,
+                                                        orientation_stddev);
 
   node_tfs->init();
 

--- a/src/tinkerforge_sensors_node.cpp
+++ b/src/tinkerforge_sensors_node.cpp
@@ -35,13 +35,18 @@ int main (int argc, char **argv)
   ros::NodeHandle private_node_handle_("~");
   private_node_handle_.param("rate", rate, int(10));
   private_node_handle_.param("host", host, string("localhost"));
-  private_node_handle_.param("port", port, int(4223)); 
+  private_node_handle_.param("port", port, int(4223));
+  private_node_handle_.param("linear_acceleration_stddev", linear_acceleration_stddev, double(0.1));
+  private_node_handle_.param("angular_velocity_stddev", angular_velocity_stddev, double(0.1));
+  private_node_handle_.param("magnetic_field_stddev", magnetic_field_stddev, double(0.1));
+  private_node_handle_.param("orientation_stddev ", orientation_stddev , double(0.1));
+
 
   // create a new LaserTransformer object.
   TinkerforgeSensors *node_tfs = new TinkerforgeSensors(host, port);
 
   node_tfs->init();
-  
+
   // read UIDs;
   std::vector<SensorConf> sensor_conf_vec;
   SensorConf sensor_conf;
@@ -71,7 +76,7 @@ int main (int argc, char **argv)
   for (Iter = node_tfs->sensors.begin(); Iter != node_tfs->sensors.end(); ++Iter)
   {
     std::cout << "node::" << "::" << (*Iter)->getUID() << "::" << (*Iter)->getTopic() << std::endl;
-    
+
     switch((*Iter)->getType())
     {
       case AMBIENT_LIGHT_DEVICE_IDENTIFIER:

--- a/src/tinkerforge_sensors_node.cpp
+++ b/src/tinkerforge_sensors_node.cpp
@@ -43,7 +43,7 @@ int main (int argc, char **argv)
   private_node_handle_.param("linear_acceleration_stddev", linear_acceleration_stddev, double(0.1));
   private_node_handle_.param("angular_velocity_stddev", angular_velocity_stddev, double(0.1));
   private_node_handle_.param("magnetic_field_stddev", magnetic_field_stddev, double(0.1));
-  private_node_handle_.param("orientation_stddev ", orientation_stddev , double(0.1));
+  private_node_handle_.param("orientation_stddev", orientation_stddev , double(0.1));
 
 
   // create a new LaserTransformer object.


### PR DESCRIPTION
This pull request only makes the BRICK IMU [REP 145](http://www.ros.org/reps/rep-0145.html) compliant. It now features:

- Covariances for accelerometer, gyroscope, magnetometer and fused heading output use reading from rosparam
- Covariances other than the diagonal are 0
- Frame_id reading from rosparam
- Standard update rate of 100 Hz (instead of the old 10 Hz)
- Example launchfile with the new parameters 
- Updated reamde.md with the new parameters
- Updated readme.md with standard ROS package info (Subscribed topics, published topics etc. )